### PR TITLE
Fixed  issue with Blueprint GetStarted

### DIFF
--- a/terraform/blueprints/README.md
+++ b/terraform/blueprints/README.md
@@ -15,17 +15,17 @@ For more exercises, go to the [Documentation site](https://docs.rafay.co/learn/q
     - The key, secret, and ID can be found in the RCTL CLI configuration file.
 	- In the Console, go to My Tools > Download CLI Config.
 
-```
+```text
 artifacts/credentials/config.json
 ```
 
 - Update tfvars file with following variables. Optionally, you can use the tfvars file as-is.
 - Note: For the purposes of this exercise, the number of variables has been limited.
 
-```
+```text
 terraform.tfvars
 
-#Poject name variable
+#Project name variable
 project                 = "<PROJECT_NAME>"
 
 #Blueprint/Addons specific variables
@@ -34,6 +34,9 @@ blueprint_version      = "<BLUEPRINT_VERSION>"
 base_blueprint         = "minimal"
 base_blueprint_version = "1.22.0"
 ```
+
+- Update the Blueprints main.tf file with a project name to share the blueprint with. Path to file: /modules/blueprints/.
+- Note: If the shared project name does not exist in your console, you may see an error message when running the ```terraform apply``` command.
 
 ## BUILD & RUN
 

--- a/terraform/blueprints/main.tf
+++ b/terraform/blueprints/main.tf
@@ -10,4 +10,5 @@ module "blueprint" {
   blueprint_version      = var.blueprint_version
   base_blueprint         = var.base_blueprint
   base_blueprint_version = var.base_blueprint_version
+  depends_on             = [module.project]
 }

--- a/terraform/blueprints/modules/blueprints/main.tf
+++ b/terraform/blueprints/modules/blueprints/main.tf
@@ -20,7 +20,7 @@ resource "rafay_blueprint" "blueprint" {
     sharing {
       enabled = false
       projects {
-        name = "terraform"
+        name = "defaultprooject"
       }
     }
     placement {


### PR DESCRIPTION
2 fixes. 

1) Added "depends_on" flag to make sure the project is created before creating the blueprint. 

2) Added a note in the ReadMe that the project name for the shared blueprint needs to exist in the user's console.