### PR TITLE
Opa constraints to warn

### DIFF
--- a/turnkey-opa/opaconstraints/artifacts/container-limits-custom/container-limits.yaml
+++ b/turnkey-opa/opaconstraints/artifacts/container-limits-custom/container-limits.yaml
@@ -4,7 +4,7 @@ metadata:
   name: container-must-have-limits
 spec:
   match:
-    enforcementAction: deny
+    enforcementAction: warn
     kinds:
       - apiGroups: [""]
         kinds: ["Pod"]

--- a/turnkey-opa/opaconstraints/artifacts/container-resource-ratios-custom/container-resource-ratios.yaml
+++ b/turnkey-opa/opaconstraints/artifacts/container-resource-ratios-custom/container-resource-ratios.yaml
@@ -4,7 +4,7 @@ metadata:
   name: container-must-meet-memory-and-cpu-ratio
 spec:
   match:
-    enforcementAction: deny
+    enforcementAction: warn
     kinds:
       - apiGroups: [""]
         kinds: ["Pod"]

--- a/turnkey-opa/opaconstraints/artifacts/disallowed-tags-custom/disallowed-tags.yaml
+++ b/turnkey-opa/opaconstraints/artifacts/disallowed-tags-custom/disallowed-tags.yaml
@@ -4,7 +4,7 @@ metadata:
   name: container-image-must-not-have-latest-tag
 spec:
   match:
-    enforcementAction: deny
+    enforcementAction: warn
     kinds:
       - apiGroups: [""]
         kinds: ["Pod"]

--- a/turnkey-opa/opaconstraints/artifacts/replica-limits-custom/replica-limits.yaml
+++ b/turnkey-opa/opaconstraints/artifacts/replica-limits-custom/replica-limits.yaml
@@ -4,7 +4,7 @@ metadata:
   name: replica-limits
 spec:
   match:
-    enforcementAction: deny
+    enforcementAction: warn
     kinds:
       - apiGroups: ["apps"]
         kinds: ["Deployment"]

--- a/turnkey-opa/opaconstraints/artifacts/required-annotations-custom/required-annotations.yaml
+++ b/turnkey-opa/opaconstraints/artifacts/required-annotations-custom/required-annotations.yaml
@@ -4,7 +4,7 @@ metadata:
   name: all-must-have-certain-set-of-annotations
 spec:
   match:
-    enforcementAction: deny
+    enforcementAction: warn
     kinds:
       - apiGroups: [""]
         kinds: ["Service"]

--- a/turnkey-opa/opaconstraints/artifacts/required-labels-custom/required-labels.yaml
+++ b/turnkey-opa/opaconstraints/artifacts/required-labels-custom/required-labels.yaml
@@ -4,7 +4,7 @@ metadata:
   name: all-must-have-owner
 spec:
   match:
-    enforcementAction: deny
+    enforcementAction: warn
     kinds:
       - apiGroups: [""]
         kinds: ["Namespace"]

--- a/turnkey-opa/opaconstraints/artifacts/required-probes-custom/required-probes.yaml
+++ b/turnkey-opa/opaconstraints/artifacts/required-probes-custom/required-probes.yaml
@@ -4,7 +4,7 @@ metadata:
   name: must-have-probes
 spec:
   match:
-    enforcementAction: deny
+    enforcementAction: warn
     kinds:
       - apiGroups: [""]
         kinds: ["Pod"]


### PR DESCRIPTION
Per Naveen's and Mohan's recommendation of setting Reliability and Operational policies to warn and keep security and PSP restricted at deny.